### PR TITLE
Update Thor requirement to support Rails 6.1+

### DIFF
--- a/radius-cli.gemspec
+++ b/radius-cli.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "dotenv", "~> 2.5"
-  spec.add_runtime_dependency "thor", "~> 0.20"
+  spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "radius-spec", "~> 0.5"


### PR DESCRIPTION
We're currently working on upgrading Captain to Rails 6.1, which requires version 1.0 of Thor. This gem, however, had the Thor version pinned to 0.20. To support the Captain upgrade to Rails 6.1 we're upgrading the Thor dependency to 1.0. Looking over the Thor CHANGELOG there are no major breaking changes that we should need to worry about.